### PR TITLE
Handle Functions that have multiple outputs

### DIFF
--- a/src/TensorFlowDiffEq.jl
+++ b/src/TensorFlowDiffEq.jl
@@ -31,7 +31,7 @@ function solve(
 
     u0 = prob.u0
     tspan = prob.tspan
-
+    
     if dt == nothing
       error("dt must be set.")
     end
@@ -40,46 +40,59 @@ function solve(
     hl_width=alg.hl_width
     f = prob.f
 
+    outdim = length(u0)
+
     t_obs = collect(tspan[1]:dt:tspan[2])
 
     @tf begin #Automatically name nodes based on RHS
-        t = constant(t_obs) #for now, just code this in as a constant
+        t = constant(t_obs)
         tt = expand_dims(t, 2) #make it a matrix
 
+        # u_trial trail network definition
         w1 = get_variable([1,hl_width], Float64)
         b1 = get_variable([hl_width], Float64)
-        w2 = get_variable([hl_width,length(u0)], Float64)
+        w2 = get_variable([hl_width,outdim], Float64)
 
         u = u0 + tt.*nn.sigmoid(tt*w1 + b1)*w2
 
-
-        du_dt = gradients(u, tt)
+        # DiffEquation Definition
         # This whole section is a static graph generation
-        # bound to the length of t_obs
-        # todo: rewrite to by dynamic
-
-        deq_rhs_steps = Vector{Tensor}()
-        for t_ii in 1:get_shape(t,1)
-            val =  f(t[t_ii], u[t_ii,:])
-            push!(deq_rhs_steps, val)
+        if outdim>1 #FIXME: Bug in Tensorflow.jl will not concat a single tensor
+            du_dt = hcat(map(1:outdim) do u_ii
+                gradients(u[:,u_ii], tt)
+            end...)
+        else
+            du_dt = gradients(u,tt)
         end
-        deq_rhs = vcat(deq_rhs_steps...)
 
+        deq_rhs = vcat(map(1:length(t_obs)) do t_ii
+            f(t[t_ii], u[t_ii,:])
+        end...)
+       
+        #Loss function and optimisation
         loss = reduce_sum((du_dt - deq_rhs).^2)
         opt = train.minimize(train.AdamOptimizer(), loss)
     end
 
-
     run(sess, global_variables_initializer())
+
+    if (verbose)
+        @show run(sess, size(u))
+        @show run(sess, size(du_dt))
+        @show run(sess, size(deq_rhs))
+    end
+
+    verbose && println("fitting u_net(t)")
     for ii in 1:maxiters
         _, loss_o = run(sess, [opt, loss])
         if verbose && ii%50 == 1
             println(loss_o)
         end
     end
-
-
+    
+    verbose && println("get final estimates with u_net(t)")
     u_net = run(sess, u)
+    verbose && println("preparing results")
 
     if typeof(u0) <: AbstractArray
         timeseries = Vector{typeof(u0)}(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,13 +11,13 @@ f = (t,u) -> -u/5 + exp(-t/5).*cos(t)
 prob = ODEProblem(f,0.0,(0.0,2.0))
 sol = solve(prob,odetf(),dt=0.02)
 
-plot(sol,plot_analytic=true)
+#plot(sol,plot_analytic=true)
 
 
 # The real issue
 
 function lorenz(t,u)
-    du1 = 10.0(u[ 2]-u[1])
+    du1 = 10.0(u[2]-u[1])
     du2 = u[1].*(28.0-u[3]) - u[2]
     du3 = u[1].*u[2] - (8/3)*u[3]
 
@@ -26,3 +26,4 @@ end
 
 prob = ODEProblem(lorenz,[1.0,1.0,0.0],(0.0,2.0))
 sol = solve(prob,odetf(),dt=0.02)
+println("Test complete")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,19 +13,6 @@ sol = solve(prob,odetf(),dt=0.02)
 
 plot(sol,plot_analytic=true)
 
-# Toy problem 2
-
-function lorenz_tf(t,u)
-    du1 = 10.0(u[:, 2]-u[:,1])
-    du2 = u[:,1].*(28.0-u[:, 3]) - u[:, 2]
-    du3 = u[:,1].*u[:,2] - (8/3)*u[:,3]
-
-    [du1 du2 du3]
-end
-prob = ODEProblem(lorenz_tf,Float32[1.0,1.0,0.0],(0.0,100.0))
-sol = solve(prob,odetf(),dt=0.02)
-
-plot(sol)
 
 # The real issue
 
@@ -37,15 +24,5 @@ function lorenz(t,u)
     [du1 du2 du3]
 end
 
-
-function tf_function_wrapper(f,t,u)
-  du = similar(u)
-  for i in 1:size(u,1)
-    _u = view(i,:)
-    du[i,:] = f(t[i],_u)
-  end
-end
-
-wrapped_lorenz = (t,u) -> tf_function_wrapper(lorenz,t,u)
-prob = ODEProblem(wrapped_lorenz,Float32[1.0,1.0,0.0],(0.0,2.0))
+prob = ODEProblem(lorenz,[1.0,1.0,0.0],(0.0,2.0))
 sol = solve(prob,odetf(),dt=0.02)


### PR DESCRIPTION
This now handles functions with multiple outputs.
and functions do not have to be specified in a "magic" vectorised way.

(Though they do have to use only operations that are defined with TensorFlow overloads. But not much in Base is missing that.)

Everything is still row major.
I will leave that to someone else to rewrite.
Please report bugs where you find out that tensorflow does not support operations like multiplying matrixes by a scalar, to the TensorFlow.jl issues.

I think this could be speedup by using `scatter_update_nd` instead of concatenating.
But that is a theory since `scatter_update_nd` is not currently a op that tensorflow.jl exports.
Might be able to do it with `scatter_nd` and a list comprehension.
`scatter_nd` is a bit of a mind killer though. (as is `scatter_update_nd` but less so since you can do small incremental steps)
`scatter` == `setindex!` but with different semantics.

The results for the first test are a lot worse (vs https://github.com/JuliaDiffEq/NeuralNetDiffEq.jl/blob/tensorflow_demo/proto/TensorFlow%20DiffEq%20Solving.ipynb), and I am not sure why.
I may have messed something up.
It does now seem to be working for lorenze

