### PR TITLE
Add flex

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,9 +22,15 @@ function lotka_voltera_tf(t,u)
   [du1 du2]
 end
 prob = ODEProblem(lotka_voltera_tf,Float32[1.0,1.0],(Float32(0.0),Float32(10.0)))
-sol = solve(prob,odetf(hl_width=512),dt=0.01,maxiters=Int(1e4),progress_steps=500)
-
+sol = solve(prob,odetf(hl_width=[256]),dt=0.01,maxiters=Int(1e4),progress_steps=500)
 plot(sol)
+
+sol = solve(prob,odetf(hl_width=[128,128]),dt=0.01,maxiters=Int(1e4),progress_steps=500)
+plot(sol)
+
+sol = solve(prob,odetf(hl_width=[128,64, 64]),dt=0.01,maxiters=Int(1e4),progress_steps=500)
+plot(sol)
+
 
 # Toy problem 3
 


### PR DESCRIPTION
This is perhaps how we can add some flexibility to the algorithm.

It doesn't handle specifying the activation type of each layer.
At some point it might be nice to checkout ReLU units.
They are very popular for deep nets.
(At a keynote I saw by Bengio he basically said they were required, and had replaced DBN pretraining.)

Might not want to merge this til NNDiffEq has caught up, just because it makes the code less clear, for its use as an example.